### PR TITLE
fixed verification error

### DIFF
--- a/frontend/src/app/verify-email/page.tsx
+++ b/frontend/src/app/verify-email/page.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { auth } from "../../lib/firebase";
 import { sendEmailVerification } from "firebase/auth";
 
-export default function VerifyEmailPage() {
+function VerifyEmailContent() {
   const searchParams = useSearchParams();
   const email = searchParams.get("email");
   const [message, setMessage] = useState<string | null>(null);
@@ -81,5 +81,17 @@ export default function VerifyEmailPage() {
         )}
       </div>
     </main>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense fallback={
+      <main className="min-h-screen bg-[#f8f8fb] flex items-center justify-center">
+        <p className="text-slate-500 text-lg">Loading...</p>
+      </main>
+    }>
+      <VerifyEmailContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Description
Wrapped the `/verify-email` page in a `<Suspense>` boundary to fix a build-time crash caused by `useSearchParams()` being used without one.

## Related Issue
Closes #[issue-number]

## Changes Made
- Split `VerifyEmailPage` into two components: `VerifyEmailContent` (holds all logic) and a new `VerifyEmailPage` default export that wraps it in `<Suspense>`
- Added a loading fallback UI that matches the page's existing background color

## Testing
- Ran `npm run build` and confirmed the build completes successfully with no errors on `/verify-email`
- Manually tested the verify email page in the browser to confirm it still works as expected

## Documentation
No documentation updates required.

## Checklist Before Submit Pull Request
- [x] Code follows naming conventions
- [x] No debug statements left in code
- [x] All tests pass
- [x] Ready for review