### PR TITLE
Tests for profile page and settings

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -19,7 +19,9 @@ const customJestConfig = {
     "!src/**/*.test.{js,jsx,ts,tsx}",
     "!src/**/__tests__/**",
     "!src/app/layout.tsx",
-    "!src/lib/**"
+    "!src/lib/firebase/**",
+    "!src/lib/firebase.ts",
+    "!src/lib/authProviders.ts"
   ]
 };
 

--- a/frontend/src/app/dashboard/profile/page.test.tsx
+++ b/frontend/src/app/dashboard/profile/page.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProfilePage from "./page";
+
+const replaceMock = jest.fn();
+const mockRouter = {
+  replace: replaceMock,
+  push: jest.fn(),
+};
+
+let mockUser: {
+  uid: string;
+  email: string | null;
+  displayName: string | null;
+  photoURL: string | null;
+} | null = null;
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+jest.mock("@/lib/firebase", () => ({
+  auth: {},
+  db: {},
+}));
+
+jest.mock("@/components/Navbar", () => ({
+  __esModule: true,
+  default: () => <nav data-testid="navbar" />,
+}));
+
+jest.mock("firebase/auth", () => ({
+  onAuthStateChanged: jest.fn((_auth: unknown, callback: (u: typeof mockUser) => void) => {
+    callback(mockUser);
+    return jest.fn();
+  }),
+}));
+
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn(() => "mock-doc-ref"),
+  getDoc: jest.fn(),
+  setDoc: jest.fn(),
+}));
+
+const { getDoc, setDoc } = jest.requireMock("firebase/firestore") as {
+  getDoc: jest.Mock;
+  setDoc: jest.Mock;
+};
+
+async function waitForProfileForm() {
+  await screen.findByLabelText(/^first name$/i);
+}
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    getDoc.mockClear();
+    setDoc.mockClear();
+    mockUser = {
+      uid: "user-1",
+      email: "pat@example.com",
+      displayName: "Pat Display",
+      photoURL: null,
+    };
+
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        firstName: "Pat",
+        lastName: "Lee",
+        username: "patlee",
+        bio: "Mood logger",
+      }),
+    });
+
+    setDoc.mockResolvedValue(undefined);
+  });
+
+  it("redirects to login when there is no signed-in user", async () => {
+    mockUser = null;
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("shows load error when getDoc fails", async () => {
+    getDoc.mockRejectedValue(new Error("network"));
+    render(<ProfilePage />);
+
+    expect(await screen.findByText(/could not load your profile/i)).toBeInTheDocument();
+  });
+
+  it("saves trimmed profile data with setDoc", async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage />);
+
+    await waitForProfileForm();
+
+    await user.clear(screen.getByLabelText(/^first name$/i));
+    await user.type(screen.getByLabelText(/^first name$/i), "  Terry  ");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(setDoc).toHaveBeenCalled();
+    });
+
+    const [, payload] = setDoc.mock.calls[0];
+    expect(payload).toMatchObject({
+      uid: "user-1",
+      email: "pat@example.com",
+      username: "patlee",
+      firstName: "Terry",
+      lastName: "Lee",
+      bio: "Mood logger",
+    });
+
+    expect(await screen.findByText(/changes saved successfully/i)).toBeInTheDocument();
+  });
+
+  it("uses Anonymous username when display name is empty", async () => {
+    const u = userEvent.setup();
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        firstName: "",
+        lastName: "",
+        username: "",
+        bio: "",
+      }),
+    });
+
+    mockUser = {
+      uid: "user-1",
+      email: "pat@example.com",
+      displayName: null,
+      photoURL: null,
+    };
+
+    render(<ProfilePage />);
+
+    await waitForProfileForm();
+
+    await u.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(setDoc).toHaveBeenCalled();
+    });
+
+    const [, payload] = setDoc.mock.calls[0];
+    expect(payload).toMatchObject({
+      username: "Anonymous",
+      firstName: "",
+      lastName: "",
+      bio: "",
+    });
+  });
+
+  it("discard restores fields from the last loaded baseline", async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage />);
+
+    await waitForProfileForm();
+
+    await user.clear(screen.getByLabelText(/^first name$/i));
+    await user.type(screen.getByLabelText(/^first name$/i), "Changed");
+
+    expect(screen.getByLabelText(/^first name$/i)).toHaveValue("Changed");
+
+    await user.click(screen.getByRole("button", { name: /discard/i }));
+
+    expect(screen.getByLabelText(/^first name$/i)).toHaveValue("Pat");
+  });
+
+  it("shows save error when setDoc fails", async () => {
+    setDoc.mockRejectedValue(new Error("permission"));
+    const user = userEvent.setup();
+    render(<ProfilePage />);
+
+    await waitForProfileForm();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByText(/could not save changes/i)).toBeInTheDocument();
+  });
+
+  it("loads profile fields from Firestore", async () => {
+    render(<ProfilePage />);
+
+    expect(await screen.findByRole("heading", { name: /your profile/i })).toBeInTheDocument();
+
+    await waitForProfileForm();
+
+    expect(screen.getByLabelText(/^first name$/i)).toHaveValue("Pat");
+    expect(screen.getByLabelText(/^last name$/i)).toHaveValue("Lee");
+    expect(screen.getByLabelText(/^display name$/i)).toHaveValue("patlee");
+    expect(screen.getByLabelText(/^bio/i)).toHaveValue("Mood logger");
+    expect(screen.getByLabelText(/^email address$/i)).toHaveValue("pat@example.com");
+  });
+});

--- a/frontend/src/app/dashboard/profile/page.tsx
+++ b/frontend/src/app/dashboard/profile/page.tsx
@@ -9,6 +9,7 @@ import type { Timestamp } from "firebase/firestore";
 
 import Navbar from "@/components/Navbar";
 import { auth, db } from "@/lib/firebase";
+import { formatMemberSince, initials } from "@/lib/profileDisplayUtils";
 
 type UserDoc = {
   username?: string;
@@ -17,28 +18,6 @@ type UserDoc = {
   bio?: string;
   createdAt?: Timestamp;
 };
-
-function formatMemberSince(createdAt?: Timestamp): string {
-  if (!createdAt?.toDate) return "—";
-  try {
-    return createdAt.toDate().toLocaleDateString("en-US", {
-      month: "short",
-      year: "numeric",
-    });
-  } catch {
-    return "—";
-  }
-}
-
-function initials(first: string, last: string, fallback: string): string {
-  const a = first.trim().charAt(0);
-  const b = last.trim().charAt(0);
-  if (a && b) return (a + b).toUpperCase();
-  if (a) return a.toUpperCase();
-  const f = fallback.trim();
-  if (f.length >= 2) return f.slice(0, 2).toUpperCase();
-  return f.charAt(0).toUpperCase() || "?";
-}
 
 export default function ProfilePage() {
   const router = useRouter();

--- a/frontend/src/app/settings/page.test.tsx
+++ b/frontend/src/app/settings/page.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SettingsPage from "./page";
+import { auth } from "@/lib/firebase";
+
+const replaceMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/Navbar", () => ({
+  __esModule: true,
+  default: () => <nav data-testid="navbar" />,
+}));
+
+jest.mock("@/lib/firebase", () => ({
+  auth: {},
+}));
+
+const reauthenticateWithCredential = jest.fn();
+const reauthenticateWithPopup = jest.fn();
+const updatePassword = jest.fn();
+const linkWithCredential = jest.fn();
+
+let mockUser: {
+  uid: string;
+  email: string | null;
+  providerData: { providerId: string; uid: string; displayName: string | null; email: string | null; phoneNumber: string | null; photoURL: string | null }[];
+  reload: jest.Mock;
+} | null = null;
+
+jest.mock("firebase/auth", () => ({
+  onAuthStateChanged: jest.fn((_auth: unknown, callback: (u: typeof mockUser) => void) => {
+    callback(mockUser);
+    return jest.fn();
+  }),
+  EmailAuthProvider: {
+    credential: jest.fn((email: string, password: string) => ({ type: "email", email, password })),
+  },
+  GoogleAuthProvider: jest.fn(function GoogleAuthProvider() {
+    return { providerId: "google.com" };
+  }),
+  linkWithCredential: (...args: unknown[]) => linkWithCredential(...args),
+  reauthenticateWithCredential: (...args: unknown[]) => reauthenticateWithCredential(...args),
+  reauthenticateWithPopup: (...args: unknown[]) => reauthenticateWithPopup(...args),
+  updatePassword: (...args: unknown[]) => updatePassword(...args),
+}));
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as unknown as { currentUser: typeof mockUser | null }).currentUser = null;
+
+    mockUser = {
+      uid: "u1",
+      email: "sam@example.com",
+      providerData: [
+        {
+          providerId: "password",
+          uid: "u1",
+          displayName: null,
+          email: "sam@example.com",
+          phoneNumber: null,
+          photoURL: null,
+        },
+      ],
+      reload: jest.fn().mockResolvedValue(undefined),
+    };
+
+    (auth as unknown as { currentUser: typeof mockUser | null }).currentUser = mockUser;
+
+    reauthenticateWithCredential.mockResolvedValue(undefined);
+    updatePassword.mockResolvedValue(undefined);
+    reauthenticateWithPopup.mockResolvedValue(undefined);
+    linkWithCredential.mockResolvedValue(undefined);
+  });
+
+  it("redirects to login when there is no signed-in user", async () => {
+    mockUser = null;
+    (auth as unknown as { currentUser: typeof mockUser | null }).currentUser = null;
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("renders settings heading and read-only email for a signed-in user", async () => {
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole("heading", { name: /^settings$/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/your email address/i)).toHaveValue("sam@example.com");
+  });
+
+  it("shows change password when the account has a password provider", async () => {
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole("heading", { name: /change password/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/^current password$/i)).toBeInTheDocument();
+  });
+
+  it("validates mismatched new passwords before calling Firebase", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await screen.findByLabelText(/^current password$/i);
+
+    await user.type(screen.getByLabelText(/^current password$/i), "oldpass1");
+    await user.type(screen.getByLabelText(/^new password$/i), "newpass1");
+    await user.type(screen.getByLabelText(/^confirm new password$/i), "newpass2");
+
+    await user.click(screen.getByRole("button", { name: /update password/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/do not match/i);
+    expect(reauthenticateWithCredential).not.toHaveBeenCalled();
+  });
+
+  it("validates short new password before calling Firebase", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await screen.findByLabelText(/^current password$/i);
+
+    await user.type(screen.getByLabelText(/^current password$/i), "oldpass1");
+    await user.type(screen.getByLabelText(/^new password$/i), "short");
+    await user.type(screen.getByLabelText(/^confirm new password$/i), "short");
+
+    await user.click(screen.getByRole("button", { name: /update password/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/at least 6 characters/i);
+    expect(reauthenticateWithCredential).not.toHaveBeenCalled();
+  });
+
+  it("updates password after reauthentication succeeds", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await screen.findByLabelText(/^current password$/i);
+
+    await user.type(screen.getByLabelText(/^current password$/i), "current123");
+    await user.type(screen.getByLabelText(/^new password$/i), "newpass123");
+    await user.type(screen.getByLabelText(/^confirm new password$/i), "newpass123");
+
+    await user.click(screen.getByRole("button", { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(reauthenticateWithCredential).toHaveBeenCalled();
+    });
+    expect(updatePassword).toHaveBeenCalledWith(mockUser, "newpass123");
+    expect(mockUser?.reload).toHaveBeenCalled();
+
+    expect(await screen.findByText(/password updated successfully/i)).toBeInTheDocument();
+  });
+
+  it("shows add-password flow for Google-only accounts", async () => {
+    mockUser = {
+      uid: "g1",
+      email: "g@example.com",
+      providerData: [
+        {
+          providerId: "google.com",
+          uid: "google-g1",
+          displayName: "G User",
+          email: "g@example.com",
+          phoneNumber: null,
+          photoURL: null,
+        },
+      ],
+      reload: jest.fn().mockResolvedValue(undefined),
+    };
+    (auth as unknown as { currentUser: typeof mockUser | null }).currentUser = mockUser;
+
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole("heading", { name: /add a password/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /confirm with google and add password/i })
+    ).toBeInTheDocument();
+  });
+
+  it("validates add-password fields before calling Firebase", async () => {
+    mockUser = {
+      uid: "g1",
+      email: "g@example.com",
+      providerData: [
+        {
+          providerId: "google.com",
+          uid: "google-g1",
+          displayName: null,
+          email: "g@example.com",
+          phoneNumber: null,
+          photoURL: null,
+        },
+      ],
+      reload: jest.fn().mockResolvedValue(undefined),
+    };
+    (auth as unknown as { currentUser: typeof mockUser | null }).currentUser = mockUser;
+
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await screen.findByRole("heading", { name: /add a password/i });
+
+    const newPw = screen.getAllByLabelText(/^new password$/i)[0];
+    const confirmPw = screen.getByLabelText(/^confirm new password$/i);
+
+    await user.type(newPw, "abcdef");
+    await user.type(confirmPw, "abcdeg");
+
+    await user.click(
+      screen.getByRole("button", { name: /confirm with google and add password/i })
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/do not match/i);
+    expect(reauthenticateWithPopup).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -16,29 +16,8 @@ import {
 import { CheckCircle2, Lock, Mail } from "lucide-react";
 import { auth } from "@/lib/firebase";
 import { getLinkedProviders } from "@/lib/authProviders";
+import { authErrorMessage } from "@/lib/settingsAuthErrors";
 import Navbar from "@/components/Navbar";
-
-function authErrorMessage(code: string): string {
-  switch (code) {
-    case "auth/wrong-password":
-    case "auth/invalid-credential":
-      return "Current password is incorrect.";
-    case "auth/requires-recent-login":
-      return "For security, please sign out and sign in again, then try once more.";
-    case "auth/weak-password":
-      return "Password is too weak. Use at least 6 characters.";
-    case "auth/provider-already-linked":
-      return "A password is already set on this account.";
-    case "auth/credential-already-in-use":
-      return "This email or password is already used by another account.";
-    case "auth/email-already-in-use":
-      return "This email is already associated with another account.";
-    case "auth/popup-closed-by-user":
-      return "Google sign-in was cancelled.";
-    default:
-      return "Something went wrong. Please try again.";
-  }
-}
 
 export default function SettingsPage() {
   const router = useRouter();

--- a/frontend/src/lib/profileDisplayUtils.test.ts
+++ b/frontend/src/lib/profileDisplayUtils.test.ts
@@ -1,0 +1,55 @@
+import type { Timestamp } from "firebase/firestore";
+import { formatMemberSince, initials } from "./profileDisplayUtils";
+
+describe("formatMemberSince", () => {
+  it("returns em dash when createdAt is missing", () => {
+    expect(formatMemberSince(undefined)).toBe("—");
+  });
+
+  it("returns em dash when toDate is missing", () => {
+    expect(formatMemberSince({} as Timestamp)).toBe("—");
+  });
+
+  it("formats a valid Firestore timestamp", () => {
+    const ts = {
+      toDate: () => new Date(Date.UTC(2024, 0, 15)),
+    } as Timestamp;
+    expect(formatMemberSince(ts)).toMatch(/Jan/);
+    expect(formatMemberSince(ts)).toMatch(/2024/);
+  });
+
+  it("returns em dash when toDate throws", () => {
+    const ts = {
+      toDate: () => {
+        throw new Error("bad");
+      },
+    } as Timestamp;
+    expect(formatMemberSince(ts)).toBe("—");
+  });
+});
+
+describe("initials", () => {
+  it("uses first and last initials when both present", () => {
+    expect(initials("Jane", "Doe", "x")).toBe("JD");
+  });
+
+  it("uses only first when last is empty", () => {
+    expect(initials("Sam", "", "ignored")).toBe("S");
+  });
+
+  it("uses two chars from fallback when no first initial", () => {
+    expect(initials("", "", "ab")).toBe("AB");
+  });
+
+  it("uses single fallback char when shorter than two", () => {
+    expect(initials("", "", "z")).toBe("Z");
+  });
+
+  it("returns question mark when nothing usable", () => {
+    expect(initials("", "", "")).toBe("?");
+  });
+
+  it("trims whitespace before computing", () => {
+    expect(initials("  A  ", "  B  ", "")).toBe("AB");
+  });
+});

--- a/frontend/src/lib/profileDisplayUtils.test.ts
+++ b/frontend/src/lib/profileDisplayUtils.test.ts
@@ -7,13 +7,13 @@ describe("formatMemberSince", () => {
   });
 
   it("returns em dash when toDate is missing", () => {
-    expect(formatMemberSince({} as Timestamp)).toBe("—");
+    expect(formatMemberSince({} as unknown as Timestamp)).toBe("—");
   });
 
   it("formats a valid Firestore timestamp", () => {
     const ts = {
       toDate: () => new Date(Date.UTC(2024, 0, 15)),
-    } as Timestamp;
+    } as unknown as Timestamp;
     expect(formatMemberSince(ts)).toMatch(/Jan/);
     expect(formatMemberSince(ts)).toMatch(/2024/);
   });
@@ -23,7 +23,7 @@ describe("formatMemberSince", () => {
       toDate: () => {
         throw new Error("bad");
       },
-    } as Timestamp;
+    } as unknown as Timestamp;
     expect(formatMemberSince(ts)).toBe("—");
   });
 });

--- a/frontend/src/lib/profileDisplayUtils.ts
+++ b/frontend/src/lib/profileDisplayUtils.ts
@@ -1,0 +1,23 @@
+import type { Timestamp } from "firebase/firestore";
+
+export function formatMemberSince(createdAt?: Timestamp): string {
+  if (!createdAt?.toDate) return "—";
+  try {
+    return createdAt.toDate().toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+export function initials(first: string, last: string, fallback: string): string {
+  const a = first.trim().charAt(0);
+  const b = last.trim().charAt(0);
+  if (a && b) return (a + b).toUpperCase();
+  if (a) return a.toUpperCase();
+  const f = fallback.trim();
+  if (f.length >= 2) return f.slice(0, 2).toUpperCase();
+  return f.charAt(0).toUpperCase() || "?";
+}

--- a/frontend/src/lib/settingsAuthErrors.test.ts
+++ b/frontend/src/lib/settingsAuthErrors.test.ts
@@ -1,0 +1,31 @@
+import { authErrorMessage } from "./settingsAuthErrors";
+
+describe("authErrorMessage", () => {
+  it("maps wrong password codes", () => {
+    expect(authErrorMessage("auth/wrong-password")).toBe("Current password is incorrect.");
+    expect(authErrorMessage("auth/invalid-credential")).toBe("Current password is incorrect.");
+  });
+
+  it("maps requires recent login", () => {
+    expect(authErrorMessage("auth/requires-recent-login")).toContain("sign out");
+  });
+
+  it("maps weak password", () => {
+    expect(authErrorMessage("auth/weak-password")).toContain("6 characters");
+  });
+
+  it("maps provider and credential conflicts", () => {
+    expect(authErrorMessage("auth/provider-already-linked")).toContain("already set");
+    expect(authErrorMessage("auth/credential-already-in-use")).toContain("already used");
+    expect(authErrorMessage("auth/email-already-in-use")).toContain("already associated");
+  });
+
+  it("maps popup cancelled", () => {
+    expect(authErrorMessage("auth/popup-closed-by-user")).toContain("cancelled");
+  });
+
+  it("returns generic message for unknown codes", () => {
+    expect(authErrorMessage("auth/unknown")).toBe("Something went wrong. Please try again.");
+    expect(authErrorMessage("")).toBe("Something went wrong. Please try again.");
+  });
+});

--- a/frontend/src/lib/settingsAuthErrors.ts
+++ b/frontend/src/lib/settingsAuthErrors.ts
@@ -1,0 +1,21 @@
+export function authErrorMessage(code: string): string {
+  switch (code) {
+    case "auth/wrong-password":
+    case "auth/invalid-credential":
+      return "Current password is incorrect.";
+    case "auth/requires-recent-login":
+      return "For security, please sign out and sign in again, then try once more.";
+    case "auth/weak-password":
+      return "Password is too weak. Use at least 6 characters.";
+    case "auth/provider-already-linked":
+      return "A password is already set on this account.";
+    case "auth/credential-already-in-use":
+      return "This email or password is already used by another account.";
+    case "auth/email-already-in-use":
+      return "This email is already associated with another account.";
+    case "auth/popup-closed-by-user":
+      return "Google sign-in was cancelled.";
+    default:
+      return "Something went wrong. Please try again.";
+  }
+}

--- a/frontend/tests/profile-settings.spec.ts
+++ b/frontend/tests/profile-settings.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test("profile page sends unauthenticated visitors to login", async ({ page }) => {
+  await page.goto("/dashboard/profile");
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test("settings page sends unauthenticated visitors to login", async ({ page }) => {
+  await page.goto("/settings");
+  await expect(page).toHaveURL(/\/login/);
+});


### PR DESCRIPTION
# Pull Request Template

## Description
This PR adds tests for the profile page and the account settings page. Pure display/auth helper logic in small src/lib modules with unit tests, and the pages are covered with Jest and React Testing Library (Firebase is mocked). There are also two Playwright checks that unauthenticated visits to profile and settings end up on the login route.

# Issues
Resolves #56 

## Changes Made
Profile and settings now import shared helpers instead of keeping that logic only inside the pages. New unit tests cover those helpers. New page tests cover the main flows (load, save, errors, password rules, redirects). A small Playwright spec covers the auth redirect behavior.


## Testing
Ran npm test in frontend. Ran playwright test tests/profile-settings.spec.ts from frontend.

## Checklist Before Submit Pull Request
- Code follows naming conventions
- No debug statements left in code
- All tests pass
- Ready for review
