### PR TITLE
profile picture upload and display

### DIFF
--- a/frontend/src/app/dashboard/profile/page.tsx
+++ b/frontend/src/app/dashboard/profile/page.tsx
@@ -8,8 +8,9 @@ import { doc, getDoc, setDoc } from "firebase/firestore";
 import type { Timestamp } from "firebase/firestore";
 
 import Navbar from "@/components/Navbar";
-import { auth, db } from "@/lib/firebase";
+import { auth, db, storage } from "@/lib/firebase";
 import { formatMemberSince, initials } from "@/lib/profileDisplayUtils";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 
 type UserDoc = {
   username?: string;
@@ -17,6 +18,7 @@ type UserDoc = {
   lastName?: string;
   bio?: string;
   createdAt?: Timestamp;
+  profilePicture?: string;
 };
 
 export default function ProfilePage() {
@@ -29,18 +31,21 @@ export default function ProfilePage() {
   const [displayName, setDisplayName] = useState("");
   const [bio, setBio] = useState("");
   const [email, setEmail] = useState("");
+  const [profilePicture, setProfilePicture] = useState<string | null>(null);
 
   const [loadingProfile, setLoadingProfile] = useState(true);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [uploading, setUploading] = useState(false);
 
   const baselineRef = useRef({
     firstName: "",
     lastName: "",
     displayName: "",
     bio: "",
+    profilePicture: null as string | null,
   });
 
   const applyBaseline = useCallback(() => {
@@ -49,6 +54,7 @@ export default function ProfilePage() {
     setLastName(b.lastName);
     setDisplayName(b.displayName);
     setBio(b.bio);
+    setProfilePicture(b.profilePicture);
   }, []);
 
   useEffect(() => {
@@ -80,6 +86,7 @@ export default function ProfilePage() {
         const ln = data.lastName ?? "";
         const dn = data.username ?? authUser.displayName ?? "";
         const bi = data.bio ?? "";
+        const pfp = data.profilePicture ?? null;
 
         if (cancelled) return;
 
@@ -87,11 +94,13 @@ export default function ProfilePage() {
         setLastName(ln);
         setDisplayName(dn);
         setBio(bi);
+        setProfilePicture(pfp);
         baselineRef.current = {
           firstName: fn,
           lastName: ln,
           displayName: dn,
           bio: bi,
+          profilePicture: pfp,
         };
         setMemberSinceTs(data.createdAt);
       } catch {
@@ -135,6 +144,7 @@ export default function ProfilePage() {
         lastName: lastName.trim(),
         displayName: username,
         bio: bio.trim(),
+        profilePicture: profilePicture,
       };
       setDisplayName(username);
       setSaved(true);
@@ -172,6 +182,46 @@ export default function ProfilePage() {
         <p className="text-slate-500 text-sm">Loading…</p>
       </div>
     );
+  }
+
+  async function handleUpload(file: File) {
+    if (!authUser) return;
+
+    setUploading(true);
+  
+    if (!file.type.startsWith("image/")) {
+      alert("Please upload an image");
+      return;
+    }
+  
+    if (file.size > 2 * 1024 * 1024) {
+      alert("Max size is 2MB");
+      return;
+    }
+  
+    try {
+      const storageRef = ref(storage, `profilePictures/${authUser.uid}/avatar.jpg`);
+  
+      await uploadBytes(storageRef, file);
+      const url = await getDownloadURL(storageRef);
+  
+      await setDoc(
+        doc(db, "users", authUser.uid),
+        {
+          profilePicture: url,
+        },
+        { merge: true }
+      );
+  
+      setAuthUser({ ...authUser, photoURL: url });
+      setProfilePicture(url);
+  
+    } catch (err) {
+      console.error(err);
+      alert("Upload failed");
+    } finally {
+      setUploading(false);
+    }
   }
 
   return (
@@ -231,10 +281,10 @@ export default function ProfilePage() {
                   </h2>
                   <div className="flex items-center gap-6">
                     <div className="relative shrink-0">
-                      {authUser.photoURL ? (
+                      {profilePicture || authUser.photoURL ? (
                         // eslint-disable-next-line @next/next/no-img-element -- OAuth avatar URLs are external
                         <img
-                          src={authUser.photoURL}
+                          src={profilePicture || authUser.photoURL!}
                           alt=""
                           className="w-20 h-20 rounded-full object-cover shadow-inner"
                         />
@@ -252,14 +302,23 @@ export default function ProfilePage() {
                         Member since {memberSince}
                       </p>
                       <div className="flex flex-wrap gap-3">
-                        <button
-                          type="button"
-                          disabled
-                          title="Photo upload is not available yet"
-                          className="px-4 py-1.5 bg-brand-600/50 text-white text-sm font-medium rounded-lg cursor-not-allowed opacity-70"
-                        >
-                          Upload photo
-                        </button>
+                        <label className={`px-4 py-1.5 text-white text-sm font-medium rounded-lg cursor-pointer hover:bg-brand-500
+                                            ${uploading 
+                                              ? "bg-brand-400 cursor-not-allowed" 
+                                              : "bg-brand-600 hover:bg-brand-500"
+                                            }`}>
+                          {uploading ? "Uploading..." : "Upload Photo"}
+                          <input
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={(e) => {
+                              if (e.target.files?.[0]) {
+                                handleUpload(e.target.files[0]);
+                              }
+                            }}
+                          />
+                        </label>
                         <button
                           type="button"
                           disabled

--- a/frontend/src/components/AvatarDropdown.tsx
+++ b/frontend/src/components/AvatarDropdown.tsx
@@ -26,6 +26,7 @@ export default function AvatarDropdown({
 
     const [username, setUsername] = useState("");
     const [email, setEmail] = useState("");
+    const [profilePicture, setProfilePicture] = useState<string | null>(null);
 
     useEffect(() => {
         const getCredentials = async () => {
@@ -37,6 +38,7 @@ export default function AvatarDropdown({
                     const userData = docSnap.data();
                     setEmail(userData.email);
                     setUsername(userData.username);
+                    setProfilePicture(userData.profilePicture ?? null);
                 }
                 }
         };
@@ -86,7 +88,15 @@ export default function AvatarDropdown({
             onClick={() => setOpen(!open)}
             className="w-8 h-8 rounded-full bg-brand-600 flex items-center justify-center text-white text-sm font-medium focus:outline-none focus:ring-2 focus:ring-purple-400"
           >
-            {String(username)[0]}
+            {profilePicture ? (
+              <img
+                src={profilePicture}
+                alt="avatar"
+                className="w-full h-full object-cover rounded-full"
+              />
+            ) : (
+              String(username)[0]
+            )}
           </button>
 
           { open && (

--- a/frontend/src/components/MoodChart 2.tsx
+++ b/frontend/src/components/MoodChart 2.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+type MoodData = {
+  dateLabel: string; // e.g. "Mon", "Apr 15"
+  score: number;     // e.g. 1-5 or float
+};
+
+export default function MoodChart({ data }: { data: MoodData[] }) {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full w-full text-sm text-slate-500 dark:text-slate-400 min-h-[200px]">
+        Not enough mood entries yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full min-h-[200px]">
+      <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={data} margin={{ top: 10, right: 10, left: -25, bottom: 0 }}>
+        <defs>
+          <linearGradient id="colorScore" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.4} />
+            <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} strokeOpacity={0.15} />
+        <XAxis 
+          dataKey="dateLabel" 
+          axisLine={false} 
+          tickLine={false} 
+          tick={{ fontSize: 11, fill: "#94a3b8" }} 
+          dy={10} 
+        />
+        <YAxis 
+          axisLine={false} 
+          tickLine={false} 
+          tick={{ fontSize: 11, fill: "#94a3b8" }} 
+          domain={[1, 5]} 
+          ticks={[1, 2, 3, 4, 5]} 
+        />
+        <Tooltip
+          contentStyle={{
+            borderRadius: "12px",
+            border: "none",
+            boxShadow: "0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)",
+            backgroundColor: "rgba(255, 255, 255, 0.9)",
+            backdropFilter: "blur(8px)",
+          }}
+          itemStyle={{ color: "#0f172a", fontWeight: "bold" }}
+          labelStyle={{ color: "#64748b", margin: 0, padding: 0 }}
+        />
+        <Area
+          type="monotone"
+          dataKey="score"
+          stroke="#8b5cf6"
+          strokeWidth={3}
+          fillOpacity={1}
+          fill="url(#colorScore)"
+          isAnimationActive={true}
+          animationDuration={1500}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -17,4 +17,4 @@ const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);
-// export const storage = getStorage(app); - has not been set up yet
+export const storage = getStorage(app);


### PR DESCRIPTION
# Pull Request Template

## Description
This PR enables the user to upload a profile picture. Once a user clicks 'Upload', they can upload an image file and it is stored in Firebase storage under the path `profilePictures/{user.uid}/avatar.jpg`. The public URL of the uploaded file is fetched and set as the `profilePicture` field in the user's doc. This URL is fetched from firebase and displayed in both the user's Profile and `AvatarDropdown`. 

## Related Issue
Issue #61 

## Changes Made
- Updated `frontend/src/app/dashboard/profile/page.tsx` with profile upload logic
- Updated `frontend/src/components/AvatarDropdown.tsx` to display the new profile picture.

## Checklist Before Submit Pull Request
- [x] Code follows naming conventions
- [x] No debug statements left in code
- [x] All tests pass
- [x] Ready for review
