### PR TITLE
Updated dashboard to delete mood entry

### DIFF
--- a/frontend/src/app/dashboard/history/page.tsx
+++ b/frontend/src/app/dashboard/history/page.tsx
@@ -8,10 +8,14 @@ import {
   getDocs,
   orderBy,
   query,
+  doc,
+  deleteDoc
 } from "firebase/firestore";
 
 import { auth, db } from "@/lib/firebase";
 import DashboardHeader from "@/components/DashboardHeader";
+import { MoreHorizontal } from "lucide-react";
+import { Trash2 } from "lucide-react";
 
 type MoodEntry = {
   id: string;
@@ -87,6 +91,9 @@ export default function MoodHistoryPage() {
   const [moodFilter, setMoodFilter] = useState(0);
   const [range, setRange] = useState("30 Days");
   const [page, setPage] = useState(1);
+  const [error, setError] = useState("");
+  const [deleted, setDeleted] = useState(false);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => setUser(u));
@@ -120,7 +127,7 @@ export default function MoodHistoryPage() {
     };
 
     fetchEntries();
-  }, [user]);
+  }, [user, deleted]);
 
   const now = new Date();
 
@@ -174,6 +181,50 @@ export default function MoodHistoryPage() {
     const d = toDate(e.date);
     return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
   }).length;
+
+  useEffect(() => {
+    const handleClickOutside = () => {
+      setOpenMenuId(null);
+    };
+  
+    if (openMenuId !== null) {
+      window.addEventListener("click", handleClickOutside);
+    }
+  
+    return () => {
+      window.removeEventListener("click", handleClickOutside);
+    };
+  }, [openMenuId]);
+
+  const handleDelete = async (entryId: string) => {
+    try {
+      if (!user) {
+        return;
+      }
+  
+      const entryRef = doc(db, "users", user.uid, "moodEntries", entryId);
+  
+      await deleteDoc(entryRef);
+  
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Failed to delete entry");
+      }
+      alert(error);
+    } finally {
+      setOpenMenuId(null);
+      setDeleted(true);
+    }
+  };
+
+  useEffect(() => {
+    if (deleted) {
+      const timer = setTimeout(() => setDeleted(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [deleted]);
 
   return (
     <main className="min-h-screen bg-slate-50 dark:bg-slate-950 font-sans text-slate-900 dark:text-slate-50">
@@ -298,6 +349,12 @@ export default function MoodHistoryPage() {
             </div>
           </section>
 
+          { deleted &&
+            <p className="rounded-2xl border border-red-200 dark:border-red-800 bg-red-50/80 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 m-4">
+              Entry deleted.
+            </p>
+          }
+
           <section className="rounded-3xl bg-white/80 dark:bg-slate-950/80 border border-slate-200/80 dark:border-slate-800/80 shadow-lg shadow-slate-900/5">
             <div className="px-6 py-5 space-y-4">
               {loading ? (
@@ -309,13 +366,14 @@ export default function MoodHistoryPage() {
                   No mood entries found for the selected filters.
                 </p>
               ) : (
+
                 pageSlice.map((entry) => {
                   const mood = moodStyles[entry.emojiScore] ?? moodStyles[3];
 
                   return (
                     <article
                       key={entry.id}
-                      className="rounded-2xl border border-slate-100 dark:border-slate-900 bg-slate-50/80 dark:bg-slate-950/60 p-4"
+                      className="relative rounded-2xl border border-slate-100 dark:border-slate-900 bg-slate-50/80 dark:bg-slate-950/60 p-4"
                     >
                       <div className="flex items-start gap-4">
                         <div
@@ -345,6 +403,32 @@ export default function MoodHistoryPage() {
                                 Score: {entry.moodScore.toFixed(2)}
                               </span>
                             )}
+
+                          <button
+                              onClick={(e) =>
+                                { e.stopPropagation();
+                                  setOpenMenuId(openMenuId === entry.id ? null : entry.id);
+                                }
+                              }
+                              className="ml-auto p-1 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-800 transition"
+                            >
+                              <MoreHorizontal className="w-5 h-5 text-slate-500" />
+                            </button>
+                            
+                            {openMenuId === entry.id && (
+                              <div className="absolute top-10 -right-7 z-11 w-32 rounded-xl bg-white dark:bg-slate-900 shadow-lg border border-slate-200 dark:border-slate-800 p-2">
+                                
+                                <button
+                                  onClick={() => handleDelete(entry.id)}
+                                  className="flex w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 justify-around items-center"
+                                >
+                                  <Trash2 className="w-4 h-4 text-red-500" />
+                                  Delete
+                                </button>
+
+                              </div>
+                            )}
+
                           </div>
 
                           <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -14,8 +14,12 @@ import {
   getDocs,
   query,
   orderBy,
-  limit
+  limit,
+  doc,
+  deleteDoc
 } from "firebase/firestore";
+import { MoreHorizontal } from "lucide-react";
+import { Trash2 } from "lucide-react";
 
 
 type RecentEntry = {
@@ -60,6 +64,8 @@ export default function DashboardPage() {
   const [email, setEmail] = useState("");
   const [chartRange, setChartRange] = useState("7 Days");
   const [chartData, setChartData] = useState<any[]>([]);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [deleted, setDeleted] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
@@ -98,7 +104,7 @@ export default function DashboardPage() {
   };
 
   fetchRecentEntries();
-}, [user, saved]);
+}, [user, saved, deleted]);
 
   useEffect(() => {
     if (!user) {
@@ -120,7 +126,7 @@ export default function DashboardPage() {
     };
 
     fetchChartData();
-  }, [user, saved, chartRange]);
+  }, [user, saved, chartRange, deleted]);
 
   const moods = [
     { label: "Very Bad", symbol: "😞", color: "border-amber-300", score: 1},
@@ -217,6 +223,50 @@ export default function DashboardPage() {
   }, [saved]);
 
   const ranges = ["7 Days", "30 Days", "90 Days", "All Time"];
+
+  useEffect(() => {
+    const handleClickOutside = () => {
+      setOpenMenuId(null);
+    };
+  
+    if (openMenuId !== null) {
+      window.addEventListener("click", handleClickOutside);
+    }
+  
+    return () => {
+      window.removeEventListener("click", handleClickOutside);
+    };
+  }, [openMenuId]);
+
+  const handleDelete = async (entryId: string) => {
+    try {
+      if (!user) {
+        setError("User not authenticated");
+        return;
+      }
+  
+      const entryRef = doc(db, "users", user.uid, "moodEntries", entryId);
+  
+      await deleteDoc(entryRef);
+  
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Failed to delete entry");
+      }
+    } finally {
+      setOpenMenuId(null);
+      setDeleted(true);
+    }
+  };
+
+  useEffect(() => {
+    if (deleted) {
+      const timer = setTimeout(() => setDeleted(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [deleted]);
 
   return (
     <main className="min-h-screen bg-slate-50 dark:bg-slate-950 font-sans text-slate-900 dark:text-slate-50">
@@ -378,7 +428,7 @@ export default function DashboardPage() {
                     recentEntries.map((entry) => (
                       <article
                         key={entry.id}
-                        className="flex items-start gap-4 rounded-2xl border border-slate-100 dark:border-slate-900 bg-slate-50/80 dark:bg-slate-950/60 px-4 py-3"
+                        className="relative flex items-start gap-4 rounded-2xl border border-slate-100 dark:border-slate-900 bg-slate-50/80 dark:bg-slate-950/60 px-4 py-3"
                       >
                         <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-2xl bg-white dark:bg-slate-900 text-xl shadow-sm">
                           {emojiMap[entry.emojiScore] ?? "🙂"}
@@ -389,6 +439,32 @@ export default function DashboardPage() {
                             <p className="text-xs font-semibold px-2 py-1 rounded-full bg-slate-900 text-slate-50">
                               {formatEntryDate(entry.date)}
                             </p>
+
+                            <button
+                              onClick={(e) =>
+                                { e.stopPropagation();
+                                  setOpenMenuId(openMenuId === entry.id ? null : entry.id);
+                                }
+                              }
+                              className="p-1 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-800 transition"
+                            >
+                              <MoreHorizontal className="w-5 h-5 text-slate-500" />
+                            </button>
+
+                            {openMenuId === entry.id && (
+                              <div className="absolute top-10 -right-7 z-11 w-32 rounded-xl bg-white dark:bg-slate-900 shadow-lg border border-slate-200 dark:border-slate-800 p-2">
+                                
+                                <button
+                                  onClick={() => handleDelete(entry.id)}
+                                  className="flex w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 justify-around"
+                                >
+                                  <Trash2 className="w-4 h-4 text-red-500" />
+                                  Delete
+                                </button>
+
+                              </div>
+                            )}
+
                           </div>
 
                           <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
@@ -399,6 +475,11 @@ export default function DashboardPage() {
                     ))
                   )}
                 </div>
+                { deleted &&
+                  <p className="rounded-2xl border border-red-200 dark:border-red-800 bg-red-50/80 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 m-4">
+                    Entry deleted.
+                  </p>
+                }
               </section>
             </div>
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -420,6 +420,11 @@ export default function DashboardPage() {
                 </div>
 
                 <div className="px-6 py-4 space-y-4">
+                  { deleted &&
+                    <p className="rounded-2xl border border-red-200 dark:border-red-800 bg-red-50/80 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 m-4">
+                      Entry deleted.
+                    </p>
+                  }
                   {recentEntries.length === 0 ? (
                     <div className="rounded-2xl border border-slate-100 dark:border-slate-900 bg-slate-50/80 dark:bg-slate-950/60 px-4 py-6 text-sm text-slate-500 dark:text-slate-400">
                       No mood entries yet. Save your first entry above.
@@ -456,7 +461,7 @@ export default function DashboardPage() {
                                 
                                 <button
                                   onClick={() => handleDelete(entry.id)}
-                                  className="flex w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 justify-around"
+                                  className="flex w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 justify-around items-center"
                                 >
                                   <Trash2 className="w-4 h-4 text-red-500" />
                                   Delete
@@ -475,11 +480,6 @@ export default function DashboardPage() {
                     ))
                   )}
                 </div>
-                { deleted &&
-                  <p className="rounded-2xl border border-red-200 dark:border-red-800 bg-red-50/80 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 m-4">
-                    Entry deleted.
-                  </p>
-                }
               </section>
             </div>
 


### PR DESCRIPTION
# Pull Request Template

## Description
This is a feature that allows the user to delete a mood entry. For each mood entry item, there will be a "MoreHorizontal" button, which on click shows a "Delete" pop-up. If the "Delete" button on the pop up is pressed, then the function `handleDelete` is run, which deletes the doc of that specific mood entry item. A success state message will show once the entry is deleted for 2000 milliseconds, and the current entries displayed as well as the mood chart data will be updated automatically. 

<img width="1020" height="119" alt="Screenshot 2026-04-22 at 4 27 20 PM" src="https://github.com/user-attachments/assets/a9442646-ec79-4b1c-b443-8d96f3ccf05f" />
<img width="876" height="109" alt="Screenshot 2026-04-22 at 4 28 55 PM" src="https://github.com/user-attachments/assets/a734ece6-ead9-478c-a442-5e089871c3e6" />

## Related Issue
#67 

## Changes Made
- Updated `frontend/src/app/dashboard/page.tsx` to include mood entry deletion
- Updated `frontend/src/app/dashboard/history/page.tsx` to include mood entry deletion

## Testing
N/A

## Documentation
N/A

## Checklist Before Submit Pull Request
- [x] Code follows naming conventions
- [x] No debug statements left in code
- [x] All tests pass
- [x] Ready for review
